### PR TITLE
fix/Test of selenium of featuremodels with incorrect values [Closes #53]

### DIFF
--- a/app/modules/featuremodel/tests/test_selenium.py
+++ b/app/modules/featuremodel/tests/test_selenium.py
@@ -90,7 +90,7 @@ def test_featuremodel_list_query():
 
         searcher_field = driver.find_element(By.ID, "search-uvl-query")
         time.sleep(2)
-        searcher_field.send_keys('0000-0000-0000-0005')
+        searcher_field.send_keys('0000-0000-0000-1000')
         searcher_field.send_keys(Keys.RETURN)
         time.sleep(2)
 


### PR DESCRIPTION
Because of the change of some data in the files of uvls, this test doesn't work. So, it is changed in order to work correctly with the new data.